### PR TITLE
Fix issue where Docker build cache isn't created in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,11 +19,11 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr-login
       - uses: docker/setup-buildx-action@v3
-        id: buildx
       - uses: docker/build-push-action@v6
         with:
-          builder: ${{ steps.buildx.outputs.name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: |
+            type=gha,scope=publish
+            type=registry,ref=${{ steps.ecr-login.outputs.registry }}/yamachu/host-tunnelto:latest
+          cache-to: type=gha,mode=max,scope=publish
           tags: ${{ steps.ecr-login.outputs.registry }}/yamachu/host-tunnelto:latest
           push: true


### PR DESCRIPTION
Docker build cache was not being created correctly in GitHub Actions, causing builds to take longer than necessary.

This PR addresses the issue by implementing the following improvements:

Explicitly sets the scope for GitHub Actions cache, ensuring consistent creation and reuse of the Docker build cache.
Removes unnecessary builder parameter to simplify the workflow configuration.
Adds the ECR registry as a cache source to ensure Docker layer caching works effectively.
These changes significantly reduce Docker image build times.